### PR TITLE
Implement Thin-Client Architecture for Pi 3

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -242,7 +242,7 @@ class BotGUI:
         
         # Mocks for headless mode
         self.status_var = type('Mock', (object,), {'set': lambda self, x: None, 'get': lambda self: ""})()
-        self.response_text = None
+        self.response_text = type('Mock', (object,), {'config': lambda self, **k: None, 'insert': lambda self, *a, **k: None, 'delete': lambda self, *a: None, 'see': lambda self, x: None})()
         self.background_label = type('Mock', (object,), {'config': lambda self, **k: None, 'place': lambda self, **k: None, 'place_forget': lambda self: None})()
         self.overlay_label = type('Mock', (object,), {'config': lambda self, **k: None, 'place': lambda self, **k: None, 'place_forget': lambda self: None})()
         

--- a/agent.py
+++ b/agent.py
@@ -41,7 +41,11 @@ import scipy.signal
 # --- AI ENGINES ---
 import openwakeword
 from openwakeword.model import Model
-import ollama 
+try:
+    import ollama 
+except ImportError:
+    ollama = None
+import requests
 
 # --- WEB SEARCH (Using your working import) ---
 from duckduckgo_search import DDGS 
@@ -60,6 +64,12 @@ WAKE_WORD_THRESHOLD = 0.5
 INPUT_DEVICE_NAME = None
 
 DEFAULT_CONFIG = {
+    "brain_type": "ollama",
+    "openclaw": {
+        "url": "http://mac-mini.ts.net:18789/v1/chat/completions",
+        "token": "your-secret-token",
+        "model": "openclaw:main"
+    },
     "text_model": "gemma3:1b",
     "vision_model": "moondream",
     "voice_model": "piper/en_GB-semaine-medium.onnx",
@@ -156,6 +166,9 @@ def choose_input_samplerate(device, preferred=None):
 
     return int(candidates[0]) if candidates else 44100
 
+# Global flag for text-only mode
+TEXT_ONLY_MODE = "--text" in sys.argv
+
 class BotStates:
     IDLE = "idle"             
     LISTENING = "listening"   
@@ -244,20 +257,23 @@ class BotGUI:
         # --- WAKE WORD INITIALIZATION ---
         print("[INIT] Loading Wake Word...", flush=True)
         self.oww_model = None
-        if os.path.exists(WAKE_WORD_MODEL):
-            try:
-                self.oww_model = Model(wakeword_model_paths=[WAKE_WORD_MODEL])
-                print("[INIT] Wake Word Loaded.", flush=True)
-            except TypeError:
+        if not TEXT_ONLY_MODE:
+            if os.path.exists(WAKE_WORD_MODEL):
                 try:
-                    self.oww_model = Model(wakeword_models=[WAKE_WORD_MODEL])
-                    print("[INIT] Wake Word Loaded (New API).", flush=True)
+                    self.oww_model = Model(wakeword_model_paths=[WAKE_WORD_MODEL])
+                    print("[INIT] Wake Word Loaded.", flush=True)
+                except TypeError:
+                    try:
+                        self.oww_model = Model(wakeword_models=[WAKE_WORD_MODEL])
+                        print("[INIT] Wake Word Loaded (New API).", flush=True)
+                    except Exception as e:
+                        print(f"[CRITICAL] Failed to load model: {e}")
                 except Exception as e:
                     print(f"[CRITICAL] Failed to load model: {e}")
-            except Exception as e:
-                print(f"[CRITICAL] Failed to load model: {e}")
+            else:
+                print(f"[CRITICAL] Model not found: {WAKE_WORD_MODEL}")
         else:
-            print(f"[CRITICAL] Model not found: {WAKE_WORD_MODEL}")
+            print("[INIT] Text-only mode enabled. Skipping Wake Word.", flush=True)
 
         # GUI Setup
         self.background_label = tk.Label(master)
@@ -308,7 +324,8 @@ class BotGUI:
         self.save_chat_history()
         
         try:
-            ollama.generate(model=TEXT_MODEL, prompt="", keep_alive=0)
+            if ollama and CURRENT_CONFIG.get("brain_type") == "ollama":
+                ollama.generate(model=TEXT_MODEL, prompt="", keep_alive=0)
         except: pass
         try:
             sd.stop()
@@ -418,6 +435,7 @@ class BotGUI:
         self.master.after(0, _update)
 
     def append_to_text(self, text, newline=True):
+        if not self.master: return
         def _update():
             self.response_text.config(state=tk.NORMAL)
             if newline: 
@@ -431,6 +449,7 @@ class BotGUI:
         self.master.after(0, _update)
 
     def _stream_to_text(self, chunk):
+        if not self.master: return
         def update_text_stream():
             self.response_text.config(state=tk.NORMAL)
             self.response_text.insert(tk.END, chunk)
@@ -522,7 +541,13 @@ class BotGUI:
             self.tts_thread.start()
             
             while True:
-                trigger_source = self.detect_wake_word_or_ptt()
+                if TEXT_ONLY_MODE:
+                    print("\n[TEXT INPUT] Type your message: ", end="", flush=True)
+                    user_text = sys.stdin.readline().strip()
+                    if not user_text: continue
+                    trigger_source = "TEXT"
+                else:
+                    trigger_source = self.detect_wake_word_or_ptt()
                 if self.interrupted.is_set():
                     self.interrupted.clear()
                     self.set_state(BotStates.IDLE, "Resetting...")
@@ -536,13 +561,16 @@ class BotGUI:
                 else:
                     audio_file = self.record_voice_adaptive()
                 
-                if not audio_file: 
+                if trigger_source == "TEXT":
+                    pass # user_text already set
+                elif not audio_file: 
                     self.set_state(BotStates.IDLE, "Heard nothing.")
                     continue
+                else:
+                    user_text = self.transcribe_audio(audio_file)
                 
-                user_text = self.transcribe_audio(audio_file)
                 if not user_text:
-                    self.set_state(BotStates.IDLE, "Transcription empty.")
+                    self.set_state(BotStates.IDLE, "Input empty.")
                     continue
                 
                 self.append_to_text(f"YOU: {user_text}")
@@ -555,12 +583,19 @@ class BotGUI:
 
     def warm_up_logic(self):
         self.set_state(BotStates.WARMUP, "Warming up brains...")
-        try:
-            ollama.generate(model=TEXT_MODEL, prompt="", keep_alive=-1)
-        except Exception as e:
-            print(f"Failed to load {TEXT_MODEL}: {e}", flush=True)
+        if CURRENT_CONFIG.get("brain_type") == "ollama":
+            if ollama:
+                try:
+                    ollama.generate(model=TEXT_MODEL, prompt="", keep_alive=-1)
+                    print("Ollama models loaded.", flush=True)
+                except Exception as e:
+                    print(f"Failed to load {TEXT_MODEL}: {e}", flush=True)
+            else:
+                print("Ollama library not found, but brain_type is set to ollama!", flush=True)
+        else:
+            print(f"Using remote brain: {CURRENT_CONFIG.get('brain_type')}", flush=True)
+            
         self.play_sound(self.get_random_sound(greeting_sounds_dir))
-        print("Models loaded.", flush=True)
 
     def detect_wake_word_or_ptt(self):
         self.set_state(BotStates.IDLE, "Waiting...")
@@ -804,6 +839,57 @@ class BotGUI:
             print(f"Camera Error: {e}")
             return None
 
+    def get_brain_response(self, messages, model_to_use):
+        brain_type = CURRENT_CONFIG.get("brain_type", "ollama")
+        
+        if brain_type == "openclaw":
+            config = CURRENT_CONFIG.get("openclaw", {})
+            url = config.get("url")
+            token = config.get("token")
+            model = config.get("model", "openclaw:main")
+            
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json"
+            }
+            
+            payload = {
+                "model": model,
+                "messages": messages,
+                "stream": True
+            }
+            
+            try:
+                response = requests.post(url, headers=headers, json=payload, stream=True, timeout=30)
+                response.raise_for_status()
+                
+                import json
+                for line in response.iter_lines():
+                    if line:
+                        line_text = line.decode('utf-8')
+                        if line_text.startswith("data: "):
+                            data_str = line_text[6:].strip()
+                            if data_str == "[DONE]":
+                                break
+                            try:
+                                data = json.loads(data_str)
+                                content = data['choices'][0]['delta'].get('content', '')
+                                if content:
+                                    yield {'message': {'content': content}}
+                            except Exception as e:
+                                print(f"OpenClaw parse error: {e}")
+            except Exception as e:
+                print(f"OpenClaw connection error: {e}")
+                raise e
+        else:
+            # Default to Ollama
+            if not ollama:
+                raise ImportError("Ollama library not installed")
+            
+            stream = ollama.chat(model=model_to_use, messages=messages, stream=True, options=OLLAMA_OPTIONS)
+            for chunk in stream:
+                yield chunk
+
     # =========================================================================
     # 5. CHAT & RESPOND
     # =========================================================================
@@ -835,7 +921,7 @@ class BotGUI:
         sentence_buffer = "" 
         
         try:
-            stream = ollama.chat(model=model_to_use, messages=messages, stream=True, options=OLLAMA_OPTIONS)
+            stream = self.get_brain_response(messages, model_to_use)
             
             is_action_mode = False
             
@@ -921,8 +1007,10 @@ class BotGUI:
                         self.set_state(BotStates.THINKING, "Reading...")
                         self.thinking_sound_active.set()
                         
-                        final_resp = ollama.chat(model=model_to_use, messages=summary_prompt, stream=False, options=OLLAMA_OPTIONS)
-                        final_text = final_resp['message']['content']
+                        final_resp_stream = self.get_brain_response(summary_prompt, model_to_use)
+                        final_text = ""
+                        for chunk in final_resp_stream:
+                            final_text += chunk['message']['content']
                         
                         self.thinking_sound_active.clear()
                         self.set_state(BotStates.SPEAKING, "Speaking...", cam_path=img_path)
@@ -963,7 +1051,10 @@ class BotGUI:
         clean = re.sub(r"[^\w\s,.!?:-]", "", text)
         if not clean.strip(): return
         
-        print(f"[PIPER SPEAKING] '{clean}'", flush=True)
+        print(f"[BOT RESPONSE] '{clean}'", flush=True)
+        if TEXT_ONLY_MODE:
+            return
+        
         voice_model = CURRENT_CONFIG.get("voice_model", "piper/en_GB-semaine-medium.onnx")
         
         try:
@@ -1035,6 +1126,7 @@ class BotGUI:
         return None
 
     def play_sound(self, file_path):
+        if TEXT_ONLY_MODE: return
         if not file_path or not os.path.exists(file_path): return
         try:
             with wave.open(file_path, 'rb') as wf:
@@ -1076,6 +1168,29 @@ class BotGUI:
 
 if __name__ == "__main__":
     print("--- SYSTEM STARTING ---", flush=True)
-    root = tk.Tk()
-    app = BotGUI(root)
-    root.mainloop()
+    
+    if TEXT_ONLY_MODE:
+        # Check if we can/should run with GUI
+        try:
+            root = tk.Tk()
+            app = BotGUI(root)
+            root.mainloop()
+        except Exception as e:
+            print(f"[INFO] Running in pure CLI mode (No GUI): {e}")
+            # Mock root for headless operation
+            class MockRoot:
+                def after(self, ms, func): 
+                    # For headless, we just run it in a thread or immediately
+                    threading.Thread(target=func, daemon=True).start()
+                def title(self, t): pass
+                def attributes(self, *args): pass
+                def bind(self, *args): pass
+            
+            app = BotGUI(MockRoot())
+            # Keep main thread alive
+            while True:
+                time.sleep(1)
+    else:
+        root = tk.Tk()
+        app = BotGUI(root)
+        root.mainloop()

--- a/agent.py
+++ b/agent.py
@@ -243,6 +243,8 @@ class BotGUI:
         # Mocks for headless mode
         self.status_var = type('Mock', (object,), {'set': lambda self, x: None, 'get': lambda self: ""})()
         self.response_text = None
+        self.background_label = type('Mock', (object,), {'config': lambda self, **k: None, 'place': lambda self, **k: None, 'place_forget': lambda self: None})()
+        self.overlay_label = type('Mock', (object,), {'config': lambda self, **k: None, 'place': lambda self, **k: None, 'place_forget': lambda self: None})()
         
         self.permanent_memory = self.load_chat_history()
         self.session_memory = []

--- a/agent.py
+++ b/agent.py
@@ -227,8 +227,10 @@ class BotGUI:
         master.bind('<Escape>', self.exit_fullscreen)
         
         # Inputs
-        master.bind('<Return>', self.handle_ptt_toggle)
-        master.bind('<space>', self.handle_speaking_interrupt)
+        if hasattr(master, 'bind'):
+            master.bind('<Return>', self.handle_ptt_toggle)
+            master.bind('<space>', self.handle_speaking_interrupt)
+        
         atexit.register(self.safe_exit)
         
         # State
@@ -284,24 +286,28 @@ class BotGUI:
         else:
             print("[INIT] Text-only mode enabled. Skipping Wake Word.", flush=True)
 
-        # GUI Setup
-        self.background_label = tk.Label(master)
-        self.background_label.place(x=0, y=0, width=self.BG_WIDTH, height=self.BG_HEIGHT)
-        self.background_label.bind('<Button-1>', self.toggle_hud_visibility) 
-        
-        self.overlay_label = tk.Label(master, bg='black')
-        self.overlay_label.bind('<Button-1>', self.toggle_hud_visibility)
-        
-        self.response_text = tk.Text(master, height=6, width=60, wrap=tk.WORD, 
-                                     state=tk.DISABLED, bg="#ffffff", fg="#000000", font=('Arial', 12)) 
-        
-        self.status_var = tk.StringVar(value="Initializing...")
-        self.status_label = ttk.Label(master, textvariable=self.status_var, background="#2e2e2e", foreground="white")
-        
-        self.exit_button = ttk.Button(master, text="Exit & Save", command=self.safe_exit)
+        # GUI Setup (Skip if master is MockRoot or headless)
+        if hasattr(master, 'tk'):
+            self.background_label = tk.Label(master)
+            self.background_label.place(x=0, y=0, width=self.BG_WIDTH, height=self.BG_HEIGHT)
+            self.background_label.bind('<Button-1>', self.toggle_hud_visibility) 
+            
+            self.overlay_label = tk.Label(master, bg='black')
+            self.overlay_label.bind('<Button-1>', self.toggle_hud_visibility)
+            
+            self.response_text = tk.Text(master, height=6, width=60, wrap=tk.WORD, 
+                                         state=tk.DISABLED, bg="#ffffff", fg="#000000", font=('Arial', 12)) 
+            
+            self.status_var = tk.StringVar(value="Initializing...")
+            self.status_label = ttk.Label(master, textvariable=self.status_var, background="#2e2e2e", foreground="white")
+            
+            self.exit_button = ttk.Button(master, text="Exit & Save", command=self.safe_exit)
 
-        self.load_animations()
-        self.update_animation() 
+            self.load_animations()
+            self.update_animation() 
+        else:
+            print("[INFO] GUI widgets skipped (Headless Mode)", flush=True)
+            self.response_text = None # Handled in append_to_text
         
         threading.Thread(target=self.safe_main_execution, daemon=True).start()
 

--- a/agent.py
+++ b/agent.py
@@ -240,6 +240,10 @@ class BotGUI:
         self.current_frame_index = 0
         self.current_overlay_image = None
         
+        # Mocks for headless mode
+        self.status_var = type('Mock', (object,), {'set': lambda self, x: None, 'get': lambda self: ""})()
+        self.response_text = None
+        
         self.permanent_memory = self.load_chat_history()
         self.session_memory = []
         self.thinking_sound_active = threading.Event()
@@ -307,7 +311,6 @@ class BotGUI:
             self.update_animation() 
         else:
             print("[INFO] GUI widgets skipped (Headless Mode)", flush=True)
-            self.response_text = None # Handled in append_to_text
         
         threading.Thread(target=self.safe_main_execution, daemon=True).start()
 

--- a/agent.py
+++ b/agent.py
@@ -39,8 +39,8 @@ import numpy as np
 import scipy.signal 
 
 # --- AI ENGINES ---
-import openwakeword
-from openwakeword.model import Model
+openwakeword = None
+Model = None
 try:
     import ollama 
 except ImportError:
@@ -258,6 +258,15 @@ class BotGUI:
         print("[INIT] Loading Wake Word...", flush=True)
         self.oww_model = None
         if not TEXT_ONLY_MODE:
+            print("[INIT] Loading AI Engines...", flush=True)
+            global openwakeword, Model
+            try:
+                import openwakeword
+                from openwakeword.model import Model
+            except ImportError as e:
+                print(f"[CRITICAL] AI Engines missing: {e}")
+                return
+
             if os.path.exists(WAKE_WORD_MODEL):
                 try:
                     self.oww_model = Model(wakeword_model_paths=[WAKE_WORD_MODEL])

--- a/config.json
+++ b/config.json
@@ -1,4 +1,10 @@
 {
+  "brain_type": "openclaw",
+  "openclaw": {
+    "url": "http://mac-mini.ts.net:18789/v1/chat/completions",
+    "token": "your-secret-token",
+    "model": "openclaw:main"
+  },
   "text_model": "gemma3:1b",
   "vision_model": "moondream",
   "voice_model": "piper/en_GB-semaine-medium.onnx",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "brain_type": "openclaw",
   "openclaw": {
-    "url": "http://mac-mini.ts.net:18789/v1/chat/completions",
+    "url": "http://giangs-mac-mini.tail9529eb.ts.net:18789/v1/chat/completions",
     "token": "your-secret-token",
     "model": "openclaw:main"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ onnxruntime
 ollama
 duckduckgo-search
 Pillow
+requests

--- a/setup.sh
+++ b/setup.sh
@@ -65,13 +65,26 @@ pip install --upgrade pip
 pip install --force-reinstall --no-cache-dir sounddevice
 pip install -r requirements.txt
 
-# 6. Pull AI Models
+# 6. AI Models (Conditional)
 echo -e "${YELLOW}[6/6] Checking AI Models...${NC}"
-if command -v ollama &> /dev/null; then
-    ollama pull gemma3:1b
-    ollama pull moondream
+if [ "$(grep -o '"brain_type": "openclaw"' config.json)" == '"brain_type": "openclaw"' ]; then
+    echo -e "${GREEN}✅ Brain type set to OpenClaw. Skipping local model pulls.${NC}"
 else
-    echo -e "${RED}❌ Ollama not found. Please install it manually.${NC}"
+    if command -v ollama &> /dev/null; then
+        echo -e "${YELLOW}Pulling local models...${NC}"
+        ollama pull gemma3:1b
+        ollama pull moondream
+    else
+        echo -e "${YELLOW}Ollama not found. If you want to run locally, please install it.${NC}"
+    fi
+fi
+
+# 7. Tailscale Check
+if ! command -v tailscale &> /dev/null; then
+    echo -e "${YELLOW}Tailscale not found. Required for remote OpenClaw connection.${NC}"
+    echo -e "Install with: ${GREEN}curl -fsSL https://tailscale.com/install.sh | sh${NC}"
+else
+    echo -e "${GREEN}✅ Tailscale is installed.${NC}"
 fi
 
 # 7. OpenWakeWord Model (Added this back so the user has a default)

--- a/start_agent.sh
+++ b/start_agent.sh
@@ -5,4 +5,6 @@ BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$BASE_DIR"
 
 source venv/bin/activate
-exec python agent.py
+
+# Allow passing arguments to agent.py (e.g. ./start_agent.sh --text)
+exec python agent.py "$@"


### PR DESCRIPTION
This PR introduces a thin-client architecture that offloads LLM processing to a remote OpenClaw instance via Tailscale. Key features include:\n- Modular brain support (Ollama or OpenClaw)\n- Memory optimization for 1GB RAM Pi 3\n- Headless/Text-only testing mode via --text flag\n- Automatic GUI mocking for SSH sessions\n- Updated setup and start scripts