### PR TITLE
Fix wake-word download URL in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -75,9 +75,19 @@ else
 fi
 
 # 7. OpenWakeWord Model (Added this back so the user has a default)
+# The old `raw/main/...` path 404s since openWakeWord v0.6.0 removed bundled
+# model files from the repo. Prefer the copy that ships inside the installed
+# `openwakeword` pip package; fall back to the v0.5.1 release asset.
 if [ ! -f "wakeword.onnx" ]; then
-    echo -e "${YELLOW}Downloading default 'Hey Jarvis' wake word...${NC}"
-    curl -L -o wakeword.onnx https://github.com/dscripka/openWakeWord/raw/main/openwakeword/resources/models/hey_jarvis_v0.1.onnx
+    echo -e "${YELLOW}Installing default 'Hey Jarvis' wake word from openwakeword package...${NC}"
+    OWW_MODEL="$(./venv/bin/python -c 'import openwakeword,os;print(os.path.join(os.path.dirname(openwakeword.__file__),"resources/models/hey_jarvis_v0.1.onnx"))' 2>/dev/null)"
+    if [ -n "$OWW_MODEL" ] && [ -f "$OWW_MODEL" ]; then
+        cp "$OWW_MODEL" wakeword.onnx
+    else
+        echo -e "${YELLOW}openwakeword bundle not found, attempting network fallback...${NC}"
+        curl -fL --retry 3 -o wakeword.onnx https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/hey_jarvis_v0.1.onnx \
+            || { rm -f wakeword.onnx; echo -e "${YELLOW}Wake-word model not installed; agent.py will run without wake detection.${NC}"; }
+    fi
 fi
 
 echo -e "${GREEN}✨ Setup Complete! Run 'source venv/bin/activate' then 'python agent.py'${NC}"


### PR DESCRIPTION
## Summary

The setup script downloads the default Hey Jarvis wake-word model from
\`https://github.com/dscripka/openWakeWord/raw/main/openwakeword/resources/models/hey_jarvis_v0.1.onnx\`,
but that path now returns HTTP 404 — openWakeWord v0.6.0 deliberately removed the bundled model files from the repo (\`raw/main/...\` no longer resolves to a file).

\`curl -L\` happily writes the GitHub 404 HTML page to \`wakeword.onnx\`, and \`agent.py\` then crashes with \`onnxruntime ... INVALID_PROTOBUF\` the first time it tries to load the wake-word model.

This change:

- Prefers copying \`hey_jarvis_v0.1.onnx\` out of the installed \`openwakeword\` pip package (still ships it under \`resources/models/\`), which avoids a network call entirely on the happy path.
- Falls back to the v0.5.1 GitHub release asset (\`https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/hey_jarvis_v0.1.onnx\`), which is the canonical surviving location.
- If both sources fail, deletes the half-written \`wakeword.onnx\` and warns instead of leaving a corrupt file behind.

## Test plan

- [x] \`curl -fIL https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/hey_jarvis_v0.1.onnx\` → 200, ~1.27 MB octet-stream.
- [x] On a Raspberry Pi the patched script lands a real ONNX file: \`file wakeword.onnx\` → \`data\` (not \`HTML document\`).
- [x] \`python3 -c "import onnxruntime; onnxruntime.InferenceSession('./wakeword.onnx')"\` exits 0 with input \`x.1\` exposed.